### PR TITLE
Develop gvf basetypes

### DIFF
--- a/src/GVF/Cumulants.jl
+++ b/src/GVF/Cumulants.jl
@@ -21,5 +21,5 @@ struct FeatureCumulant <: AbstractCumulant
     idx::Int
 end
 
-get(cumulant::FeatureCumulant, state_tp1) = ϕ[cumulant.idx]
+get(cumulant::FeatureCumulant, state_tp1) = state_tp1[cumulant.idx]
 get(cumulant::FeatureCumulant, state_t, action_t, state_tp1, action_tp1, preds_tilde) = get(cumulant, state_tp1)

--- a/src/GVF/Cumulants.jl
+++ b/src/GVF/Cumulants.jl
@@ -10,3 +10,16 @@
 abstract type AbstractCumulant <: AbstractParameterFunction end
 
 function get(cumulant::AbstractCumulant, state_t, action_t, state_tp1, action_tp1, preds_tilde) end
+
+
+"""
+    FeatureCumulant
+
+    - Basic Cumulant which takes the value c_t = s_tp1[idx] for 1<=idx<=length(s_tp1)
+"""
+struct FeatureCumulant <: AbstractCumulant
+    idx::Int
+end
+
+get(cumulant::FeatureCumulant, state_tp1) = ϕ[cumulant.idx]
+get(cumulant::FeatureCumulant, state_t, action_t, state_tp1, action_tp1, preds_tilde) = get(cumulant, state_tp1)

--- a/src/GVF/Discounts.jl
+++ b/src/GVF/Discounts.jl
@@ -9,6 +9,11 @@ end
 get(γ::AbstractDiscount, state_t, action_t, state_tp1) = get(γ::AbstractDiscount, state_t, action_t, state_tp1, nothing, nothing)
 get(γ::AbstractDiscount, state_tp1) = get(γ::AbstractDiscount, nothing, nothing, state_tp1, nothing, nothing)
 
+struct ConstantDiscount{T} <: AbstractDiscount
+    γ::T
+end
 
+get(cd::ConstantDiscount) = cd.γ
+get(cd::ConstantDiscount, state_t, action_t, state_tp1, action_tp1, preds_tilde) = get(cd)
 
 

--- a/src/GVF/GVF.jl
+++ b/src/GVF/GVF.jl
@@ -40,6 +40,18 @@ get(gvf::GVF, state_t, action_t, state_tp1, preds_tilde) =
     get(gvf::GVF, state_t, action_t, state_tp1, nothing, preds_tilde)
 
 
+struct PredictionGVF{C<:AbstractCumulant, D<:AbstractDiscount, P<:AbstractPolicy} <: AbstractGVF
+    cumulant::C
+    discount::D
+    policy::NullPolicy
+end
 
+PredictionGVF(cumulant::AbstractCumulant, discount::AbstractDiscount) = PredictionGVF(cumulant, discount, NullPolicy())
 
+function get(gvf::GVF, state_tp1)
+    c = get(gvf.cumulant, state_tp1)
+    γ = get(gvf.discount)
+    π_prob = get(gvf.policy)
+    return c, γ, π_prob
+end
 

--- a/src/GVF/GVF.jl
+++ b/src/GVF/GVF.jl
@@ -1,6 +1,3 @@
-
-
-
 import Base.get
 
 abstract type AbstractParameterFunction end
@@ -40,7 +37,7 @@ get(gvf::GVF, state_t, action_t, state_tp1, preds_tilde) =
     get(gvf::GVF, state_t, action_t, state_tp1, nothing, preds_tilde)
 
 
-struct PredictionGVF{C<:AbstractCumulant, D<:AbstractDiscount, P<:AbstractPolicy} <: AbstractGVF
+struct PredictionGVF{C<:AbstractCumulant, D<:AbstractDiscount} <: AbstractGVF
     cumulant::C
     discount::D
     policy::NullPolicy
@@ -48,10 +45,13 @@ end
 
 PredictionGVF(cumulant::AbstractCumulant, discount::AbstractDiscount) = PredictionGVF(cumulant, discount, NullPolicy())
 
-function get(gvf::GVF, state_tp1)
+function get(gvf::PredictionGVF, state_tp1)
     c = get(gvf.cumulant, state_tp1)
     γ = get(gvf.discount)
-    π_prob = get(gvf.policy)
+    π_prob = get(gvf.policy, state_tp1)
     return c, γ, π_prob
 end
+
+get(gvf::PredictionGVF, state_t, action_t, state_tp1, action_tp1, preds_tilde) = get(gvf, state_tp1)
+
 

--- a/src/GVF/Policies.jl
+++ b/src/GVF/Policies.jl
@@ -6,3 +6,9 @@ function get(π::AbstractPolicy, state_t, action_t, state_tp1, action_tp1, preds
 get(π::AbstractPolicy, state_t, action_t) = get(π::AbstractPolicy, state_t, action_t, nothing, nothing, nothing)
 
 
+struct NullPolicy <: AbstractPolicy
+end
+
+get(π::NullPolicy, state_t) = 1.0
+get(π::NullPolicy, state_t, action_t) = get(π, state_t)
+

--- a/src/GVF/Policies.jl
+++ b/src/GVF/Policies.jl
@@ -1,3 +1,5 @@
+export NullPolicy
+
 import Base.get
 
 abstract type AbstractPolicy <: AbstractParameterFunction end

--- a/src/Horde.jl
+++ b/src/Horde.jl
@@ -1,6 +1,7 @@
 module Horde
 
-export GVF, get_parameters, get
+export GVF, PredictionGVF, get_parameters, get,
+    FeatureCumulant, ConstantDiscount, NullPolicy
 include("GVF/GVF.jl")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,9 +8,7 @@ function example_test()
     return ret
 end
 
-
 function tests()
-
     @testset "Tests" begin
         @testset "Example Test" begin
             @test example_test() == true
@@ -18,4 +16,70 @@ function tests()
     end
 end
 
-tests()
+
+# ==================
+# ---  GVF Tests ---
+# ==================
+
+function test_construction(obj_class, args...)
+    try
+        obj_class(args...)
+        return true
+    catch y
+        @show y
+        return false
+    end
+end
+
+function gvf_tests()
+    @testset "GVF Tests" begin
+        @testset "GVF" begin
+            @test test_construction(GVF, FeatureCumulant(1), ConstantDiscount(0.9), NullPolicy())
+        end
+
+        @testset "PredictionGVF" begin
+            # GVF builds
+            @test test_construction(PredictionGVF, FeatureCumulant(1), ConstantDiscount(0.9), NullPolicy())
+            @test test_construction(PredictionGVF, FeatureCumulant(1), ConstantDiscount(0.9))
+
+            # GVF returns the right thing
+            gvf = PredictionGVF(FeatureCumulant(2), ConstantDiscount(0.78), NullPolicy())
+            @test all(get(gvf, [1,2,3]) .== [2, 0.78, 1.0])
+            @test all(get(gvf, [5,5,5], 1, [1,2,3], 2, [0.1,0.2,0.3]) .== [2, 0.78, 1.0])
+        end
+    end
+
+    @testset "Discount Tests" begin
+        @testset "Constant Discount" begin
+            # discount builds
+            @test test_construction(ConstantDiscount, 0.9)
+            @test test_construction(ConstantDiscount, exp(complex(0.0, 0.5)))
+
+            # discount returns the correct value
+            @test get(ConstantDiscount(0.9)) == 0.9
+            @test get(ConstantDiscount(exp(complex(0.0, 0.5)))) == exp(complex(0.0, 0.5))
+        end
+    end
+
+    @testset "Cumulant Tests" begin
+        @testset "Feature Cumulant" begin
+            # cumulant builds
+            @test test_construction(FeatureCumulant, 1)
+
+            # cumulant returns correct value
+            @test get(FeatureCumulant(3), [1 2 3]) == 3
+        end
+    end
+
+    @testset "Policy Tests" begin
+        @testset "Null Policy" begin
+            # policy builds
+            @test test_construction(NullPolicy)
+
+            # policy returns the correct value
+            @test get(NullPolicy(), [1,2,3]) == 1.0
+        end
+    end
+end
+
+gvf_tests()


### PR DESCRIPTION
Trying out how the API would work with some simple base types. I'm not completely convinced this is a great solution so let me know what you think

I think some parameter functions will naturally take different arguments in their most-common use-case. For example, for constant discounts we don't really need to pass anything to `get`. I think that a clear convention would be to define the intended`get(T, arg1,...)` function with the common use-case parameters, and then below define the fall-back `get(T, st, at, stp1, atp1, preds_tilde) = get(T, arg1,...)` for when it's used in a more broad context.

I'm also thinking that it might be good to define subtypes of the base GVF afterall. When doing on-policy prediction for example we'll tend to only need to pass s_tp1 to the GVF. We could multiple dispatch `get(GVF, stp1) = ...` but this might start to get confusing as more use-cases arise, so in the long run it might be useful to have GVF subtypes which are tailored to some common specific use-cases